### PR TITLE
Cancel teleport instead of sending player to spawn

### DIFF
--- a/src/main/java/org/reprogle/dimensionpause/events/ListenerManager.java
+++ b/src/main/java/org/reprogle/dimensionpause/events/ListenerManager.java
@@ -10,7 +10,7 @@ public class ListenerManager {
 	 * @param plugin The Honeypot plugin instance
 	 */
 	public static void setupListeners(Plugin plugin) {
-		plugin.getServer().getPluginManager().registerEvents(new PlayerChangedWorldEventListener(), plugin);
+		plugin.getServer().getPluginManager().registerEvents(new PlayerTeleportEventListener(), plugin);
 		plugin.getServer().getPluginManager().registerEvents(new PlayerInteractEventListener(), plugin);
 		plugin.getServer().getPluginManager().registerEvents(new PortalCreateEventListener(), plugin);
 	}

--- a/src/main/java/org/reprogle/dimensionpause/events/PlayerTeleportEventListener.java
+++ b/src/main/java/org/reprogle/dimensionpause/events/PlayerTeleportEventListener.java
@@ -5,17 +5,21 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
-import org.bukkit.event.player.PlayerChangedWorldEvent;
+import org.bukkit.event.player.PlayerTeleportEvent;
 import org.reprogle.dimensionpause.ConfigManager;
 import org.reprogle.dimensionpause.DimensionPausePlugin;
 import org.reprogle.dimensionpause.commands.CommandFeedback;
 
-public class PlayerChangedWorldEventListener implements Listener {
+public class PlayerTeleportEventListener implements Listener {
 
 	@EventHandler(priority = EventPriority.HIGHEST)
-	public static void onPlayerChangeWorld(PlayerChangedWorldEvent event) {
+	public static void onPlayerTeleport(PlayerTeleportEvent event) {
+		// If the teleport is localized within the world, ignore the event
+		if (event.getFrom().getWorld().equals(event.getTo().getWorld())) {
+			return;
+		}
 		// Grab the environment and the player. If the player is teleporting to the overworld, ignore it
-		World.Environment env = event.getPlayer().getWorld().getEnvironment();
+		World.Environment env = event.getTo().getWorld().getEnvironment();
 		Player p = event.getPlayer();
 		if (env.equals(World.Environment.NORMAL)) return;
 
@@ -30,8 +34,8 @@ public class PlayerChangedWorldEventListener implements Listener {
 			if (DimensionPausePlugin.ds.canBypass(p, env.equals(World.Environment.NETHER) ? netherBypass : endBypass))
 				return;
 
-			// If the all of the above fail, force them back to the world they came from
-			p.teleport(event.getFrom().getSpawnLocation());
+			// If the all of the above fail cancel the event
+			event.setCancelled(true);
 
 			// Send the player the proper title for the environment they tried to access
 			String environment = env.equals(World.Environment.NETHER) ? "nether" : "end";


### PR DESCRIPTION
Instead of listening to the `PlayerChangedWorldEvent`, which is not cancelable, listen to the `PlayerTeleportEvent`. This way we can cancel the teleport all together instead of teleporting the player to spawn.