### PR TITLE
Support for 1.17+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,8 +94,13 @@
         <dependency>
             <groupId>io.papermc.paper</groupId>
             <artifactId>paper-api</artifactId>
-            <version>1.20.1-R0.1-SNAPSHOT</version>
+            <version>1.17.1-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.kyori</groupId>
+            <artifactId>adventure-text-minimessage</artifactId>
+            <version>4.17.0</version>
         </dependency>
         <dependency>
             <groupId>dev.dejvokep</groupId>

--- a/src/main/java/org/reprogle/dimensionpause/DimensionPausePlugin.java
+++ b/src/main/java/org/reprogle/dimensionpause/DimensionPausePlugin.java
@@ -27,7 +27,7 @@ public final class DimensionPausePlugin extends JavaPlugin {
 
 		new UpdateChecker(this, "https://raw.githubusercontent.com/TerrorByteTW/DimensionPause/master/version.txt").getVersion(latest -> {
 			//noinspection UnstableApiUsage
-			if (Integer.parseInt(latest.replace(".", "")) > Integer.parseInt(this.getPluginMeta().getVersion().replace(".", ""))) {
+			if (Integer.parseInt(latest.replace(".", "")) > Integer.parseInt(this.getDescription().getVersion().replace(".", ""))) {
 				Component updateMessage = Component.text()
 						.append(CommandFeedback.getChatPrefix())
 						.append(Component.text(" "))

--- a/src/main/java/org/reprogle/dimensionpause/commands/CommandFeedback.java
+++ b/src/main/java/org/reprogle/dimensionpause/commands/CommandFeedback.java
@@ -117,7 +117,7 @@ public class CommandFeedback {
 		final Component mainTitle = Component.text().append(mm.deserialize(ConfigManager.getPluginConfig().getString("dimensions." + environment + ".alert.title.title"))).build();
 		final Component subtitle = Component.text().append(mm.deserialize(ConfigManager.getPluginConfig().getString("dimensions." + environment + ".alert.title.subtitle"))).build();
 
-		final Title.Times times = Title.Times.times(Duration.ofMillis(500), Duration.ofSeconds(3), Duration.ofMillis(500));
+		final Title.Times times = Title.Times.of(Duration.ofMillis(500), Duration.ofSeconds(3), Duration.ofMillis(500));
 		return Title.title(mainTitle, subtitle, times);
 	}
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
 name: DimensionPause
 version: '${project.version}'
 main: org.reprogle.dimensionpause.DimensionPausePlugin
-api-version: '1.20'
+api-version: '1.17'
 prefix: "DimensionPause"
 authors: [TerrorByteTW]
 description: Allows you to pause dimensions to prevent players from entering them


### PR DESCRIPTION
Support could almost definitely be pulled back to work with even older versions, however since there is no demand for that right now 1.17+ should suffice.